### PR TITLE
Resin jetson tx2 debian with explicit openjdk8

### DIFF
--- a/Server/Dockerfile.template
+++ b/Server/Dockerfile.template
@@ -162,6 +162,7 @@ RUN mkdir -p /etc/default \
 
 # packages that we want to use at runtime, but you may not want
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
     maven \
     python \
     ruby \

--- a/Server/Dockerfile.template
+++ b/Server/Dockerfile.template
@@ -56,8 +56,8 @@ RUN set -ex; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
         openjdk-8-jdk \
-        ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" 
-    
+        ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
+        ; \
 # verify that "docker-java-home" returns what we expect
     [ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ]; \
     \

--- a/Server/Dockerfile.template
+++ b/Server/Dockerfile.template
@@ -1,5 +1,5 @@
 # https://github.com/eiodiagnostics/balena-jetson-tx2-experiments
-FROM resin/jetson-tx2-debian:stretch-build
+FROM resin/jetson-tx2-debian:stretch
 LABEL Description="This image is used create a privileged container for Nvidia Jetson TX2 using BalenaOS" 
 LABEL Vendor="EIO Diagnostics" 
 LABEL Version="1.0"

--- a/Server/Dockerfile.template
+++ b/Server/Dockerfile.template
@@ -1,13 +1,33 @@
-# START FROM: https://github.com/open-horizon/cogwerx-jetson-tx2
+# https://github.com/eiodiagnostics/balena-jetson-tx2-experiments
+FROM resin/jetson-tx2-debian
+LABEL Description="This image is used create a privileged container for Nvidia Jetson TX2 using BalenaOS" 
+LABEL Vendor="EIO Diagnostics" 
+LABEL Version="1.0"
+
+LABEL Author="jason@eiodiagnostics.com"
+
+####################################################################
+# START SNIPPET FROM: https://github.com/open-horizon/cogwerx-jetson-tx2/Dockerfile.cudabase
+# MODIFICATIONS: 
+# - commented out MAINTAINER nuculur@gmail.com
+# - removed 
+#   ## Clean up (don't remove cuda libs... used by child containers)
+#   RUN apt-get -y autoremove && apt-get -y autoclean
+#   RUN rm -rf /var/cache/apt
+####################################################################
 # see also https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
 # FROM aarch64/ubuntu
 # FROM arm64v8/ubuntu:xenial-20180123
-FROM balenalib/jetson-tx2-debian-openjdk:8-jdk-stretch-build-20181207
+# fails to run systemd:
+# FROM balenalib/jetson-tx2-debian-openjdk:8-jdk-stretch-build-20181207
 # FROM balenalib/jetson-tx2-debian-openjdk:8-jre-stretch-run-20181207
+# fails to run systemd:
+# FROM balenalib/jetson-tx2-ubuntu-openjdk:8-jdk-xenial-build-20181207
+# FROM balenalib/jetson-tx2-ubuntu-openjdk:8-jre-xenial-run-20181207
 
-#AUTHOR bmwshop@gmail.com
-MAINTAINER nuculur@gmail.com
-# MODIFIED jason@eiodiagnostics.com
+# https://github.com/open-horizon/cogwerx-jetson-tx2
+# AUTHOR bmwshop@gmail.com
+# MAINTAINER nuculur@gmail.com
 
 # This is the base container for the Jetson TX2 board with drivers (with cuda)
 # base URL for NVIDIA libs
@@ -60,9 +80,79 @@ RUN ln -sf /usr/lib/aarch64-linux-gnu/tegra/libGL.so /usr/lib/aarch64-linux-gnu/
 
 # D.R. – need to do this for some strange reason (for jetson tx2)
 RUN ln -s /usr/lib/aarch64-linux-gnu/libcuda.so /usr/lib/aarch64-linux-gnu/libcuda.so.1
-# END FROM: https://github.com/open-horizon/cogwerx-jetson-tx2
+####################################################################
+# END SNIPPET FROM: https://github.com/open-horizon/cogwerx-jetson-tx2
+####################################################################
 
 ENV PATH="${PATH}:/usr/local/cuda/bin"
+
+
+####################################################################
+# START SNIPPET FROM; https://github.com/balena-io-library/base-images/blob/master/balena-base-images/openjdk/jetson-tx2/ubuntu/xenial/8-jdk/build/Dockerfile
+# MODIFICATIONS: commented out "rm -rf /var/lib/apt/lists/*;""
+####################################################################
+# A few reasons for installing distribution-provided OpenJDK:
+#
+#  1. Oracle.  Licensing prevents us from redistributing the official JDK.
+#
+#  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
+#     really hairy.
+#
+#     For some sample build times, see Debian's buildd logs:
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-7
+
+# Default to UTF-8 file.encoding
+ENV LANG C.UTF-8
+
+# add a simple script that can auto-detect the appropriate JAVA_HOME value
+# based on whether the JDK or only the JRE is installed
+RUN { \
+        echo '#!/bin/sh'; \
+        echo 'set -e'; \
+        echo; \
+        echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
+    } > /usr/local/bin/docker-java-home \
+    && chmod +x /usr/local/bin/docker-java-home
+
+# do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
+RUN ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-java-home
+ENV JAVA_HOME /docker-java-home
+
+RUN set -ex; \
+    \
+# deal with slim variants not having man page directories (which causes "update-alternatives" to fail)
+    if [ ! -d /usr/share/man/man1 ]; then \
+        mkdir -p /usr/share/man/man1; \
+    fi; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        software-properties-common \
+    ; \
+    add-apt-repository ppa:openjdk-r/ppa; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        openjdk-8-jdk \
+    ; # \
+    #rm -rf /var/lib/apt/lists/*; \
+    #\
+# verify that "docker-java-home" returns what we expect
+    [ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ]; \
+    \
+# update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
+    update-alternatives --get-selections | awk -v home="$(readlink -f "$JAVA_HOME")" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+# ... and verify that it actually worked for one of the alternatives we care about
+    update-alternatives --query java | grep -q 'Status: manual'
+####################################################################
+# END SNIPPET FROM: https://github.com/balena-io-library/base-images/blob/master/balena-base-images/openjdk/jetson-tx2/ubuntu/xenial/8-jdk/build/Dockerfile
+####################################################################
+
+# switch on systemd init system in container -- requires "privileged: true" in docker-compose.yml
+ENV INITSYSTEM on
+
+# Tomcat warns that we need to define default locale
+RUN mkdir -p /etc/default \
+    && echo "LANG=en_CA.UTF-8" > /etc/default/locale
 
 # packages that we want to use at runtime, but you may not want
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -72,14 +162,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ssh \
     tomcat8 \
     tomcat8-admin
-
-
-# switch on systemd init system in container -- requires "privileged: true" in docker-compose.yml
-ENV INITSYSTEM on
-
-# Tomcat warns that we need to define default locale
-RUN mkdir -p /etc/default \
-    && echo "LANG=en_CA.UTF-8" > /etc/default/locale
 
 WORKDIR /usr/src/app
 COPY . ./

--- a/Server/Dockerfile.template
+++ b/Server/Dockerfile.template
@@ -7,6 +7,73 @@ LABEL Version="1.0"
 LABEL Author="jason@eiodiagnostics.com"
 
 ####################################################################
+# START SNIPPET FROM; https://github.com/balena-io-library/base-images/blob/master/balena-base-images/openjdk/jetson-tx2/debian/stretch/8-jdk/build/Dockerfile
+# MODIFICATIONS: removed "rm -rf /var/lib/apt/lists/*
+# 
+# A few reasons for installing distribution-provided OpenJDK:
+#
+#  1. Oracle.  Licensing prevents us from redistributing the official JDK.
+#
+#  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
+#     really hairy.
+#
+#     For some sample build times, see Debian's buildd logs:
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-8
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bzip2 \
+        unzip \
+        xz-utils 
+
+# Default to UTF-8 file.encoding
+ENV LANG C.UTF-8
+
+# add a simple script that can auto-detect the appropriate JAVA_HOME value
+# based on whether the JDK or only the JRE is installed
+RUN { \
+        echo '#!/bin/sh'; \
+        echo 'set -e'; \
+        echo; \
+        echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
+    } > /usr/local/bin/docker-java-home \
+    && chmod +x /usr/local/bin/docker-java-home
+
+# do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
+RUN ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-java-home
+ENV JAVA_HOME /docker-java-home
+
+# see https://bugs.debian.org/775775
+# and https://github.com/docker-library/java/issues/19#issuecomment-70546872
+ENV CA_CERTIFICATES_JAVA_VERSION 20170531+nmu1
+
+RUN set -ex; \
+    \
+# deal with slim variants not having man page directories (which causes "update-alternatives" to fail)
+    if [ ! -d /usr/share/man/man1 ]; then \
+        mkdir -p /usr/share/man/man1; \
+    fi; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        openjdk-8-jdk \
+        ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" 
+    
+# verify that "docker-java-home" returns what we expect
+    [ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ]; \
+    \
+# update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
+    update-alternatives --get-selections | awk -v home="$(readlink -f "$JAVA_HOME")" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
+# ... and verify that it actually worked for one of the alternatives we care about
+    update-alternatives --query java | grep -q 'Status: manual'
+
+# see CA_CERTIFICATES_JAVA_VERSION notes above
+RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
+
+####################################################################
+# END SNIPPET FROM: https://github.com/balena-io-library/base-images/blob/master/balena-base-images/openjdk/jetson-tx2/debian/stretch/8-jdk/build/Dockerfile
+####################################################################
+
+####################################################################
 # START SNIPPET FROM: https://github.com/open-horizon/cogwerx-jetson-tx2/Dockerfile.cudabase
 # MODIFICATIONS: 
 # - commented out MAINTAINER nuculur@gmail.com
@@ -85,73 +152,6 @@ RUN ln -s /usr/lib/aarch64-linux-gnu/libcuda.so /usr/lib/aarch64-linux-gnu/libcu
 ####################################################################
 
 ENV PATH="${PATH}:/usr/local/cuda/bin"
-
-
-####################################################################
-# START SNIPPET FROM; https://github.com/balena-io-library/base-images/blob/master/balena-base-images/openjdk/jetson-tx2/debian/stretch/8-jdk/build/Dockerfile
-# MODIFICATIONS: removed "rm -rf /var/lib/apt/lists/*
-# A few reasons for installing distribution-provided OpenJDK:
-#
-#  1. Oracle.  Licensing prevents us from redistributing the official JDK.
-#
-#  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
-#     really hairy.
-#
-#     For some sample build times, see Debian's buildd logs:
-#       https://buildd.debian.org/status/logs.php?pkg=openjdk-8
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        bzip2 \
-        unzip \
-        xz-utils 
-
-# Default to UTF-8 file.encoding
-ENV LANG C.UTF-8
-
-# add a simple script that can auto-detect the appropriate JAVA_HOME value
-# based on whether the JDK or only the JRE is installed
-RUN { \
-        echo '#!/bin/sh'; \
-        echo 'set -e'; \
-        echo; \
-        echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
-    } > /usr/local/bin/docker-java-home \
-    && chmod +x /usr/local/bin/docker-java-home
-
-# do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
-RUN ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-java-home
-ENV JAVA_HOME /docker-java-home
-
-# see https://bugs.debian.org/775775
-# and https://github.com/docker-library/java/issues/19#issuecomment-70546872
-ENV CA_CERTIFICATES_JAVA_VERSION 20170531+nmu1
-
-RUN set -ex; \
-    \
-# deal with slim variants not having man page directories (which causes "update-alternatives" to fail)
-    if [ ! -d /usr/share/man/man1 ]; then \
-        mkdir -p /usr/share/man/man1; \
-    fi; \
-    \
-    apt-get update; \
-    apt-get install -y --no-install-recommends \
-        openjdk-8-jdk \
-        ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
-    
-# verify that "docker-java-home" returns what we expect
-    [ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ]; \
-    \
-# update-alternatives so that future installs of other OpenJDK versions don't change /usr/bin/java
-    update-alternatives --get-selections | awk -v home="$(readlink -f "$JAVA_HOME")" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
-# ... and verify that it actually worked for one of the alternatives we care about
-    update-alternatives --query java | grep -q 'Status: manual'
-
-# see CA_CERTIFICATES_JAVA_VERSION notes above
-RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
-
-####################################################################
-# END SNIPPET FROM: https://github.com/balena-io-library/base-images/blob/master/balena-base-images/openjdk/jetson-tx2/debian/stretch/8-jdk/build/Dockerfile
-####################################################################
 
 # switch on systemd init system in container -- requires "privileged: true" in docker-compose.yml
 ENV INITSYSTEM on

--- a/Server/Dockerfile.template
+++ b/Server/Dockerfile.template
@@ -88,9 +88,8 @@ ENV PATH="${PATH}:/usr/local/cuda/bin"
 
 
 ####################################################################
-# START SNIPPET FROM; https://github.com/balena-io-library/base-images/blob/master/balena-base-images/openjdk/jetson-tx2/ubuntu/xenial/8-jdk/build/Dockerfile
-# MODIFICATIONS: commented out "rm -rf /var/lib/apt/lists/*;""
-####################################################################
+# START SNIPPET FROM; https://github.com/balena-io-library/base-images/blob/master/balena-base-images/openjdk/jetson-tx2/debian/stretch/8-jdk/build/Dockerfile
+# MODIFICATIONS: removed "rm -rf /var/lib/apt/lists/*;""
 # A few reasons for installing distribution-provided OpenJDK:
 #
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
@@ -99,7 +98,13 @@ ENV PATH="${PATH}:/usr/local/cuda/bin"
 #     really hairy.
 #
 #     For some sample build times, see Debian's buildd logs:
-#       https://buildd.debian.org/status/logs.php?pkg=openjdk-7
+#       https://buildd.debian.org/status/logs.php?pkg=openjdk-8
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bzip2 \
+        unzip \
+        xz-utils \
+    && rm -rf /var/lib/apt/lists/*
 
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
@@ -118,6 +123,10 @@ RUN { \
 RUN ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-java-home
 ENV JAVA_HOME /docker-java-home
 
+# see https://bugs.debian.org/775775
+# and https://github.com/docker-library/java/issues/19#issuecomment-70546872
+ENV CA_CERTIFICATES_JAVA_VERSION 20170531+nmu1
+
 RUN set -ex; \
     \
 # deal with slim variants not having man page directories (which causes "update-alternatives" to fail)
@@ -127,15 +136,9 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-        software-properties-common \
-    ; \
-    add-apt-repository ppa:openjdk-r/ppa; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends \
         openjdk-8-jdk \
-    ; # \
-    #rm -rf /var/lib/apt/lists/*; \
-    #\
+        ca-certificates-java="$CA_CERTIFICATES_JAVA_VERSION" \
+    
 # verify that "docker-java-home" returns what we expect
     [ "$(readlink -f "$JAVA_HOME")" = "$(docker-java-home)" ]; \
     \
@@ -143,8 +146,12 @@ RUN set -ex; \
     update-alternatives --get-selections | awk -v home="$(readlink -f "$JAVA_HOME")" 'index($3, home) == 1 { $2 = "manual"; print | "update-alternatives --set-selections" }'; \
 # ... and verify that it actually worked for one of the alternatives we care about
     update-alternatives --query java | grep -q 'Status: manual'
+
+# see CA_CERTIFICATES_JAVA_VERSION notes above
+RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
+
 ####################################################################
-# END SNIPPET FROM: https://github.com/balena-io-library/base-images/blob/master/balena-base-images/openjdk/jetson-tx2/ubuntu/xenial/8-jdk/build/Dockerfile
+# END SNIPPET FROM: https://github.com/balena-io-library/base-images/blob/master/balena-base-images/openjdk/jetson-tx2/debian/stretch/8-jdk/build/Dockerfile
 ####################################################################
 
 # switch on systemd init system in container -- requires "privileged: true" in docker-compose.yml

--- a/Server/Dockerfile.template
+++ b/Server/Dockerfile.template
@@ -1,5 +1,5 @@
 # https://github.com/eiodiagnostics/balena-jetson-tx2-experiments
-FROM resin/jetson-tx2-debian
+FROM resin/jetson-tx2-debian:stretch-build
 LABEL Description="This image is used create a privileged container for Nvidia Jetson TX2 using BalenaOS" 
 LABEL Vendor="EIO Diagnostics" 
 LABEL Version="1.0"
@@ -89,7 +89,7 @@ ENV PATH="${PATH}:/usr/local/cuda/bin"
 
 ####################################################################
 # START SNIPPET FROM; https://github.com/balena-io-library/base-images/blob/master/balena-base-images/openjdk/jetson-tx2/debian/stretch/8-jdk/build/Dockerfile
-# MODIFICATIONS: removed "rm -rf /var/lib/apt/lists/*;""
+# MODIFICATIONS: removed "rm -rf /var/lib/apt/lists/*
 # A few reasons for installing distribution-provided OpenJDK:
 #
 #  1. Oracle.  Licensing prevents us from redistributing the official JDK.
@@ -103,8 +103,7 @@ ENV PATH="${PATH}:/usr/local/cuda/bin"
 RUN apt-get update && apt-get install -y --no-install-recommends \
         bzip2 \
         unzip \
-        xz-utils \
-    && rm -rf /var/lib/apt/lists/*
+        xz-utils 
 
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8


### PR DESCRIPTION
resin-jetson-tx2-debian: Resin jetson tx2 debian (stretch) with openjdk8, cuda 9, tomcat 8

Changelog-entry: Combine resin-jetson-tx2-debian-stretch with openjdk 8, cuda 9, tomcat 8
Signed-off-by: Jason Harrison <jason@eiodiagnostics.com>